### PR TITLE
Fix http request message parse with Content-Length: 0

### DIFF
--- a/http.go
+++ b/http.go
@@ -337,7 +337,11 @@ func (http *Http) messageParser(s *HttpStream) (bool, bool) {
 				s.parseOffset += 2
 				m.bodyOffset = s.parseOffset
 				if m.ContentLength == 0 {
-					if m.version_major == 1 && m.version_minor == 0 &&
+                                        if m.IsRequest && m.hasContentLength {
+                                                // empty request body, do not read until FIN
+						m.end = s.parseOffset
+						return true, true
+                                        } else if m.version_major == 1 && m.version_minor == 0 &&
 						!m.hasContentLength {
 						if m.IsRequest {
 							// No Content-Length in a HTTP/1.0 request means

--- a/http_test.go
+++ b/http_test.go
@@ -167,6 +167,34 @@ func TestHttpParser_simpleRequest(t *testing.T) {
 
 }
 
+func TestHttpParser_Request_ContentLength_0(t *testing.T) {
+
+        http := HttpModForTests()
+        http.Send_headers = true
+        http.Send_all_headers = true
+
+        data := []byte("POST / HTTP/1.1\r\n" +
+                "user-agent: curl/7.35.0\r\n" + "host: localhost:9000\r\n" +
+                "accept: */*\r\n" +
+                "authorization: Company 1\r\n" +
+                "content-length: 0\r\n" +
+                "connection: close\r\n" +
+                "\r\n")
+
+        stream := &HttpStream{tcpStream: nil, data: data, message: new(HttpMessage)}
+
+        ok, complete := http.messageParser(stream)
+
+        if !ok {
+                t.Errorf("Parsing returned error")
+        }
+
+        if !complete {
+                t.Errorf("Expecting a complete message")
+        }
+
+}
+
 func TestHttpParser_splitResponse(t *testing.T) {
 
 	http := HttpModForTests()


### PR DESCRIPTION
Hello, 
I noticed that HTTP 1.1 requests with "Content-Length: 0" header are not handled by packetbeat.
I have got this debug output: 
```
http.go:267: DBG  Stream state=0
http.go:317: DBG  HTTP Method=POST, RequestUri=/api/notifications/alerts/
http.go:326: DBG  HTTP version 1.1
http.go:225: DBG  Header: 'user-agent' Value: 'curl/7.35.0'
http.go:225: DBG  Header: 'host' Value: 'localhost:9000'
http.go:225: DBG  Header: 'accept' Value: '*/*'
http.go:225: DBG  Header: 'authorization' Value: 'Company 1'
http.go:225: DBG  Header: 'content-length' Value: '0'
http.go:225: DBG  Header: 'connection' Value: 'close'
http.go:267: DBG  Stream state=0
http.go:181: DBG  parseResponseStatus: 200 OK
http.go:296: DBG  HTTP status_code=200, status_phrase=OK
http.go:326: DBG  HTTP version 1.0
http.go:267: DBG  Stream state=2
http.go:225: DBG  Header: 'date' Value: 'Sat, 31 Jan 2015 11:41:00 GMT'
http.go:267: DBG  Stream state=2
http.go:225: DBG  Header: 'server' Value: 'WSGIServer/0.1 Python/2.7.6'
http.go:267: DBG  Stream state=2
http.go:225: DBG  Header: 'vary' Value: 'Accept'
http.go:225: DBG  Header: 'content-type' Value: 'application/json'
http.go:225: DBG  Header: 'allow' Value: 'POST, OPTIONS'
http.go:349: DBG  Read until FIN
http.go:267: DBG  Stream state=3
http.go:376: DBG  eat body: 161
http.go:663: DBG  Received response with tuple: TcpTuple src[127.0.0.1:46441] dst[127.0.0.1:8000] stream_id[2]
http.go:667: WARN Response from unknown transaction. Ignoring: TcpTuple src[127.0.0.1:46441] dst[127.0.0.1:8000] stream_id[2]
http.go:591: DBG  Received request with tuple: TcpTuple src[127.0.0.1:46441] dst[127.0.0.1:8000] stream_id[2]```