### PR TITLE
Cleaned up Include_body_for, added additional debugging and Added Exclude_body_for option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,8 @@ type Http struct {
 	Split_cookie     bool
 	Real_ip_header   string
 	Include_body_for []string
+	Exclude_body_for []string
+
 }
 
 type Mysql struct {

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -111,8 +111,11 @@ device = "any"
 [http]
 ######
 #Only include the HTTP body if the content-type matches
-# An empty array []  will capture everything
-#Include_body_for=["text/html"]
+# An empty array []  will capture everything ***Warning this will include images as well 
+#Include_body_for=["text/"]
+######
+#Exclude the HTTP body if the content-type matches (Overrides Includes_body_for)
+#Exclude_body_for=["image/"]
 ######
 #Send The Http Headers as a specific field
 #Send_all_headers=true

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -111,6 +111,7 @@ device = "any"
 [http]
 ######
 #Only include the HTTP body if the content-type matches
+# An empty array []  will capture everything
 #Include_body_for=["text/html"]
 ######
 #Send The Http Headers as a specific field

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -52,7 +52,9 @@ device = "any"
 # configuration.
   [protocols.http]
   ports = [80, 8080, 8000, 5000, 8002]
+  ## Include the actual request: For Http this will only include the Headers of the request- See the Http section for finer controler
   #send_request=false
+  ## Include the acutal response: For Http this will only include the Heards of the response - See the Http Sections for finer controle
   #send_response=false
 
   [protocols.mysql]
@@ -107,9 +109,17 @@ device = "any"
 #hide_keywords = ["pass", "password", "passwd"]
 
 [http]
+######
+#Only include the HTTP body if the content-type matches
 #Include_body_for=["text/html"]
+######
+#Send The Http Headers as a specific field
 #Send_all_headers=true
+######
+#Remove the HTTP Authentication header
 #Strip_authorization=false
+######
+#Split All cookies to their own field
 #Split_cookie=true
 
 # vim: set ft=toml:

--- a/packetbeat.conf
+++ b/packetbeat.conf
@@ -52,6 +52,8 @@ device = "any"
 # configuration.
   [protocols.http]
   ports = [80, 8080, 8000, 5000, 8002]
+  #send_request=false
+  #send_response=false
 
   [protocols.mysql]
   ports = [3306]
@@ -103,5 +105,11 @@ device = "any"
 # This is generally useful for avoiding storing user passwords or other
 # sensitive information.
 #hide_keywords = ["pass", "password", "passwd"]
+
+[http]
+#Include_body_for=["text/html"]
+#Send_all_headers=true
+#Strip_authorization=false
+#Split_cookie=true
 
 # vim: set ft=toml:

--- a/protos/http/http.go
+++ b/protos/http/http.go
@@ -110,7 +110,7 @@ type Http struct {
 	Real_ip_header      string
 	Hide_keywords       []string
 	Strip_authorization bool
-	Include_body_for []string
+	Include_body_for 	[]string
 
 	transactionsMap map[common.HashableTcpTuple]*HttpTransaction
 
@@ -120,6 +120,7 @@ type Http struct {
 func (http *Http) InitDefaults() {
 	http.Send_request = false
 	http.Send_response = false
+	http.Include_body_for= nil
 //	http.Include_body_for =  make(map[string]bool)
 //	http.Include_body_for["all"] = false;
 }
@@ -136,6 +137,7 @@ func (http *Http) SetFromConfig(config *config.Config, meta *toml.MetaData) (err
 	if meta.IsDefined("http", "Include_body_for") {
 		http.Include_body_for = config.Http.Include_body_for
 		logp.Debug("http", "ConfigSetting: http.Include_body_for \n")
+		logp.Debug("http", "ConfigSetting: http.Include_body_for Length =%d \n",len(http.Include_body_for))
 		for _, include := range http.Include_body_for {
 			logp.Debug("http", "Value: '%s'\n", include)
 		}
@@ -858,12 +860,17 @@ func (http *Http) cutMessageBody(m *HttpMessage) []byte {
 }
 
 func (http *Http) shouldIncludeInBody(contenttype string) bool {
-	for _, include := range http.Include_body_for {
-		if strings.Contains(contenttype, include) {
-			logp.Debug("httpdetailed", "Should Include Body = true Content-Type "+contenttype+" http.Include_body_for "+include)
-			return true
+	if http.Include_body_for != nil {
+		if len(http.Include_body_for) == 0{
+			return true;
 		}
-		logp.Debug("httpdetailed", "Should Include Body = false Content-Type"+contenttype+" http.Include_body_for "+include)
+		for _, include := range http.Include_body_for {
+			if strings.Contains(contenttype, include) {
+				logp.Debug("httpdetailed", "Should Include Body = true Content-Type "+contenttype+" http.Include_body_for "+include)
+				return true
+			}
+			logp.Debug("httpdetailed", "Should Include Body = false Content-Type"+contenttype+" http.Include_body_for "+include)
+		}
 	}
 	return false
 }


### PR DESCRIPTION
I noticed that there was no easy way to include all content-try by default, so I added a way  to handle an  empty array Include_body_for=[]

Then I realized if I am including everything I might want to Exclude some things. So I implemented that option

I also noticed that none of the Http options were documented in the Config file (also noticed someone mentioning that in the issues list)

Added some extra debug to show which option is getting set
Move Debugging for "Printing" the http body from "http" to httpdetailed debug levels

I performed a quick test on the new Include_body_for =[] and Exclude_body_for=["image/"] seems to work well

[http]
Include_body_for=[]
Send_all_headers=true
Strip_authorization=false
Split_cookie=true